### PR TITLE
fix: preserve aspect ratio in thumbnail

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -4,7 +4,10 @@ use std::path::Path;
 #[cfg(feature = "image")]
 use {
     crate::{
-        utils::{_bgra_to_rgb, _bgra_to_rgba_inplace, resize_rgb_image, resize_rgba_image},
+        utils::{
+            _bgra_to_rgb, _bgra_to_rgba_inplace, preserve_aspect_ratio, resize_rgb_image,
+            resize_rgba_image,
+        },
         Address,
     },
     image::{RgbImage, RgbaImage},
@@ -281,9 +284,9 @@ impl OpenSlide {
             level,
             address: Address { x: 0, y: 0 },
         };
-
         let image = self.read_image_rgba(&region)?;
-        let image = resize_rgba_image(image, size)?;
+        let size = preserve_aspect_ratio(&size, &dimension_level0);
+        let image = resize_rgba_image(image, &size)?;
 
         Ok(image)
     }
@@ -310,7 +313,8 @@ impl OpenSlide {
         };
 
         let image = self.read_image_rgb(&region)?;
-        let image = resize_rgb_image(image, size)?;
+        let size = preserve_aspect_ratio(&size, &dimension_level0);
+        let image = resize_rgb_image(image, &size)?;
 
         Ok(image)
     }

--- a/tests/openslide.rs
+++ b/tests/openslide.rs
@@ -242,27 +242,35 @@ fn test_slide_read_image_rgba(#[case] filename: &Path) {
 }
 
 #[rstest]
-#[case(boxes_tiff())]
+#[case((boxes_tiff(), &Size { w: 96, h: 80 }))]
 #[cfg(feature = "image")]
-fn test_thumbnail_rgba(#[case] filename: &Path) {
+fn test_thumbnail_rgba(#[case] filename_and_size: (&Path, &Size)) {
+    let (filename, expected_size) = filename_and_size;
     let slide = OpenSlide::new(filename).unwrap();
 
     let size = Size { w: 100, h: 80 };
     let thumbnail = slide.thumbnail_rgba(&size).unwrap();
-    assert_eq!(thumbnail.dimensions(), (size.w, size.h));
-    assert_eq!(thumbnail.len(), (size.h * size.w * 4) as usize);
+    assert_eq!(thumbnail.dimensions(), (expected_size.w, expected_size.h));
+    assert_eq!(
+        thumbnail.len(),
+        (expected_size.h * expected_size.w * 4) as usize
+    );
 }
 
 #[rstest]
-#[case(boxes_tiff())]
+#[case((boxes_tiff(), &Size { w: 96, h: 80 }))]
 #[cfg(feature = "image")]
-fn test_thumbnail_rgb(#[case] filename: &Path) {
+fn test_thumbnail_rgb(#[case] filename_and_size: (&Path, &Size)) {
+    let (filename, expected_size) = filename_and_size;
     let slide = OpenSlide::new(filename).unwrap();
 
     let size = Size { w: 100, h: 80 };
     let thumbnail = slide.thumbnail_rgb(&size).unwrap();
-    assert_eq!(thumbnail.dimensions(), (size.w, size.h));
-    assert_eq!(thumbnail.len(), (size.h * size.w * 3) as usize);
+    assert_eq!(thumbnail.dimensions(), (expected_size.w, expected_size.h));
+    assert_eq!(
+        thumbnail.len(),
+        (expected_size.h * expected_size.w * 3) as usize
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
Change the behavior of `thumbnail_rgb` and `thumbnail_rgba` so that it matches the one of the original [Python function](https://openslide.org/api/python/#openslide.OpenSlide.get_thumbnail): it preserves the aspect ratio of the original slide, and returns a thumbnail no larger than the given shape