### PR TITLE
fix: Openslide property regex to capture properties with hyphens

### DIFF
--- a/src/properties/openslide.rs
+++ b/src/properties/openslide.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 lazy_static! {
     static ref REGEX_LEVEL_PROPERTIES: Regex =
-        Regex::new(r"level\[([0-9]+)]\.([a-zA-Z]+)").unwrap();
+        Regex::new(r"level\[([0-9]+)]\.([a-zA-Z]+(?:-[a-zA-Z]+)?)").unwrap();
 }
 
 pub const OPENSLIDE_PROPERTY_NAME_COMMENT: &str = "openslide.comment";

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -135,6 +135,42 @@ fn test_tiff_properties(#[case] filename: &Path) {
     );
     assert_eq!(properties.openslide_properties.levels[3].height, Some(31));
     assert_eq!(properties.openslide_properties.levels[3].width, Some(37));
+
+    assert_eq!(
+        properties.openslide_properties.levels[0].tile_height,
+        Some(64)
+    );
+    assert_eq!(
+        properties.openslide_properties.levels[0].tile_height,
+        Some(64)
+    );
+
+    assert_eq!(
+        properties.openslide_properties.levels[1].tile_height,
+        Some(64)
+    );
+    assert_eq!(
+        properties.openslide_properties.levels[1].tile_height,
+        Some(64)
+    );
+
+    assert_eq!(
+        properties.openslide_properties.levels[2].tile_height,
+        Some(64)
+    );
+    assert_eq!(
+        properties.openslide_properties.levels[2].tile_height,
+        Some(64)
+    );
+
+    assert_eq!(
+        properties.openslide_properties.levels[3].tile_height,
+        Some(64)
+    );
+    assert_eq!(
+        properties.openslide_properties.levels[3].tile_height,
+        Some(64)
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
The previous regex does not allow hyphens in property names, which discards things like "tile-width" and "tile-height" when parsing. The new regex matches the following:
level[123].abc
level[123].abc-def