### PR TITLE
Expose slide physical levels from generator

### DIFF
--- a/src/deepzoom.rs
+++ b/src/deepzoom.rs
@@ -129,6 +129,10 @@ impl<S: Slide, B: Borrow<S>> DeepZoomGenerator<S, B> {
         })
     }
 
+    pub fn slide_zoom_levels(&self) -> &[u32] {
+        self.slide_from_dz_level.iter().collect()
+    }
+
     pub fn level_count(&self) -> usize {
         self.level_count
     }


### PR DESCRIPTION
Having the real physical levels of slides exposed by generator is very useful. I've had this in my fork long time, first contribution among many to come. 

Thank you for such an amazing driver. 